### PR TITLE
chore: refactor kratix workflow to use reusable workflows

### DIFF
--- a/.github/workflows/kratix.yaml
+++ b/.github/workflows/kratix.yaml
@@ -46,278 +46,27 @@ jobs:
               core.setFailed(`Failed to set pending status: ${error.message}`);
             }
 
-  unit-tests-and-lint:
-    runs-on: ubuntu-latest
+  test-kratix:
     needs: [set-pending-status]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-          check-latest: true
-      - name: Unit Tests
-        run: |
-          make test
-      - name: Lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4
-          ./bin/golangci-lint run --config=.golangci-required.yml
+    uses:
+      syntasso/ci/.github/workflows/test-kratix.yaml@main
+    with:
+      sha: ${{ github.event.inputs.sha }}
 
-  system-test:
-    runs-on: ubuntu-latest
-    needs: [unit-tests-and-lint]
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-          check-latest: true
-      - name: Install Kind
-        uses: helm/kind-action@v1
-        with:
-          install_only: true
-      - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@main
-        with:
-          version: '2.4.0'
-      - name: System Tests
-        run: |
-          DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make system-test
-  core-test:
-    runs-on: ubuntu-latest
-    needs: [unit-tests-and-lint]
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-          check-latest: true
-      - name: Install Kind
-        uses: helm/kind-action@v1
-        with:
-          install_only: true
-      - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@main
-        with:
-          version: '2.4.0'
-      - name: System Tests
-        run: |
-          DOCKER_BUILDKIT=1 ACK_GINKGO_RC=true make core-test
-
-  integration-test-git:
-    runs-on: ubuntu-latest
-    needs: [unit-tests-and-lint]
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Checkout out kratix helm charts
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/helm-charts
-          path: charts
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-          check-latest: true
-      - name: Install Kind
-        uses: helm/kind-action@v1
-        with:
-          install_only: true
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-      - name: e2e-demo-test-helm-git
-        run: |
-          STATE_STORE="git" ./scripts/helm-e2e-test.sh
-  integration-test-bucket:
-    runs-on: ubuntu-latest
-    needs: [unit-tests-and-lint]
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Checkout out kratix helm charts
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/helm-charts
-          path: charts
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-          check-latest: true
-      - name: Install Kind
-        uses: helm/kind-action@v1
-        with:
-          install_only: true
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-      - name: e2e-demo-test-helm-bucket
-        run: |
-          STATE_STORE="bucket" ./scripts/helm-e2e-test.sh
-
-  tag-new-version:
-    needs: [system-test, core-test, integration-test-git, integration-test-bucket]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out kratix
-        id: checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ssh-key: ${{ secrets.ACTION_PUSH }}
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Tag new version
-        env:
-          LAST_SHA: ${{ github.event.inputs.sha }}
-        run: |
-          latest_tag="latest"
-          current_commit=${LAST_SHA:-$(git rev-parse HEAD)}
-          commit_list=$(git rev-list "$latest_tag".."$current_commit")
-          git config user.name "syntassodev"
-          git config user.email "kratix@syntasso.io"
-          echo "checking if there are new commits from main compared to the latest tag"
-          if [ -n "$commit_list" ]; then
-              echo "Current commit is ahead of the previous tag; pushing a new tag"
-              git tag -a $latest_tag -m "${latest_tag}" --force
-              git push origin $latest_tag --force
-          else
-              echo "Current commit is not ahead of the previous tag; not pushing a new tag"
-          fi
-
-  build-and-push-kratix-platform:
-    runs-on: ubuntu-latest
-    needs: [tag-new-version]
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Docker login to GHCR
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push Kratix Platform
-        run: |
-          make docker-build-and-push
-
-  build-and-push-pipeline-adapter:
-    runs-on: ubuntu-latest
-    needs: [tag-new-version]
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Docker login to GHCR
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push Pipeline
-        run: |
-          make build-and-push-work-creator
-
-  snyk-image-scan:
-    runs-on: ubuntu-latest
-    needs:
-      - build-and-push-kratix-platform
-      - build-and-push-pipeline-adapter
-    steps:
-      - name: Snyk image scan on kratix
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: docker.io/syntasso/kratix-platform
-          args: --severity-threshold=high
-      - name: Snyk image scan on pipeline-adapter
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: docker.io/syntasso/kratix-platform-pipeline-adapter
-          args: --severity-threshold=high
-
-
-  publish-release:
-    runs-on: ubuntu-latest
-    needs:
-      - snyk-image-scan
-    steps:
-      - name: Check out kratix
-        uses: actions/checkout@v4
-        id: checkout
-        with:
-          repository: syntasso/kratix
-          ref: ${{ github.event.inputs.sha }}
-      - name: Checkout out kratix helm charts
-        uses: actions/checkout@v4
-        with:
-          repository: syntasso/helm-charts
-          path: charts
-          ssh-key: ${{ secrets.HELM_REPO_SSH_KEY }}
-      - name: Create Kratix Distribution and Helm Template
-        run: |
-          ./scripts/make-distribution
-          ./charts/scripts/generate-templates-and-crds ./distribution/kratix.yaml
-        env:
-          VERSION: ${{ steps.checkout.outputs.commit }}
-      - name: Create Github Release
-        run: |
-          gh config set prompt disabled
-          gh release delete latest || true
-          gh release create latest --title latest ./distribution/**/*.yaml ./distribution/*.yaml
-        env:
-          GH_TOKEN: ${{ secrets.GH_RELEASE_CREATOR_TOKEN }}
-      - name: push-to-helm-charts
-        run: |
-          cd charts
-          git config user.name “syntassodev”
-          git config user.email “kratix@syntasso.io”
-          git add kratix/
-          git diff --cached --quiet && exit 0 || true
-
-          git commit -m"update kratix package"
-          git push origin main
+  release-kratix:
+    needs: [test-kratix]
+    uses:
+      syntasso/ci/.github/workflows/release-kratix.yaml@main
+    with:
+      sha: ${{ github.event.inputs.sha }}
+    secrets: inherit
 
   final-status-check:
     runs-on: ubuntu-latest
     needs: 
       - set-pending-status
-      - unit-tests-and-lint
-      - system-test
-      - core-test
-      - integration-test-git
-      - integration-test-bucket
-      - tag-new-version
-      - build-and-push-kratix-platform
-      - build-and-push-pipeline-adapter
-      - publish-release
+      - test-kratix
+      - release-kratix
     if: always()
     steps:
       - name: Generate GitHub App token
@@ -339,13 +88,8 @@ jobs:
 
             // Collect job results from workflow context
             const jobResults = [
-              '${{ needs.unit-tests-and-lint.result }}',
-              '${{ needs.system-test.result }}',
-              '${{ needs.integration-test.result }}',
-              '${{ needs.tag-new-version.result }}',
-              '${{ needs.build-and-push-kratix-platform.result }}',
-              '${{ needs.build-and-push-pipeline-adapter.result }}',
-              '${{ needs.publish-release.result }}'
+              '${{ needs.test-kratix.result }}',
+              '${{ needs.release-kratix.result }}',
             ];
 
             const hasFailed = jobResults.some(result => 

--- a/.github/workflows/release-kratix.yaml
+++ b/.github/workflows/release-kratix.yaml
@@ -1,0 +1,163 @@
+name: Kratix
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit sha of Kratix'
+        required: true
+        type: string
+      message:
+        description: 'Commit message'
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+      message:
+        type: string
+        required: false
+    secrets:
+      ACTION_PUSH:
+        required: true
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      SNYK_TOKEN:
+        required: true
+      HELM_REPO_SSH_KEY:
+        required: true
+      GH_RELEASE_CREATOR_TOKEN:
+        required: true
+
+jobs:
+  tag-new-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out kratix
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.ACTION_PUSH }}
+          repository: syntasso/kratix
+          ref: ${{ github.event.inputs.sha }}
+      - name: Tag new version
+        env:
+          LAST_SHA: ${{ github.event.inputs.sha }}
+        run: |
+          latest_tag="latest"
+          current_commit=${LAST_SHA:-$(git rev-parse HEAD)}
+          commit_list=$(git rev-list "$latest_tag".."$current_commit")
+          git config user.name "syntassodev"
+          git config user.email "kratix@syntasso.io"
+          echo "checking if there are new commits from main compared to the latest tag"
+          if [ -n "$commit_list" ]; then
+              echo "Current commit is ahead of the previous tag; pushing a new tag"
+              git tag -a $latest_tag -m "${latest_tag}" --force
+              git push origin $latest_tag --force
+          else
+              echo "Current commit is not ahead of the previous tag; not pushing a new tag"
+          fi
+
+  build-and-push-kratix-platform:
+    runs-on: ubuntu-latest
+    needs: [tag-new-version]
+    steps:
+      - name: Check out kratix
+        uses: actions/checkout@v4
+        with:
+          repository: syntasso/kratix
+          ref: ${{ github.event.inputs.sha }}
+      - name: Docker login to GHCR
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Kratix Platform
+        run: |
+          make docker-build-and-push
+
+  build-and-push-pipeline-adapter:
+    runs-on: ubuntu-latest
+    needs: [tag-new-version]
+    steps:
+      - name: Check out kratix
+        uses: actions/checkout@v4
+        with:
+          repository: syntasso/kratix
+          ref: ${{ github.event.inputs.sha }}
+      - name: Docker login to GHCR
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Pipeline
+        run: |
+          make build-and-push-work-creator
+
+  snyk-image-scan:
+    runs-on: ubuntu-latest
+    needs:
+      - build-and-push-kratix-platform
+      - build-and-push-pipeline-adapter
+    steps:
+      - name: Snyk image scan on kratix
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: docker.io/syntasso/kratix-platform
+          args: --severity-threshold=high
+      - name: Snyk image scan on pipeline-adapter
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: docker.io/syntasso/kratix-platform-pipeline-adapter
+          args: --severity-threshold=high
+
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs:
+      - snyk-image-scan
+    steps:
+      - name: Check out kratix
+        uses: actions/checkout@v4
+        id: checkout
+        with:
+          repository: syntasso/kratix
+          ref: ${{ github.event.inputs.sha }}
+      - name: Checkout out kratix helm charts
+        uses: actions/checkout@v4
+        with:
+          repository: syntasso/helm-charts
+          path: charts
+          ssh-key: ${{ secrets.HELM_REPO_SSH_KEY }}
+      - name: Create Kratix Distribution and Helm Template
+        run: |
+          ./scripts/make-distribution
+          ./charts/scripts/generate-templates-and-crds ./distribution/kratix.yaml
+        env:
+          VERSION: ${{ steps.checkout.outputs.commit }}
+      - name: Create Github Release
+        run: |
+          gh config set prompt disabled
+          gh release delete latest || true
+          gh release create latest --title latest ./distribution/**/*.yaml ./distribution/*.yaml
+        env:
+          GH_TOKEN: ${{ secrets.GH_RELEASE_CREATOR_TOKEN }}
+      - name: push-to-helm-charts
+        run: |
+          cd charts
+          git config user.name “syntassodev”
+          git config user.email “kratix@syntasso.io”
+          git add kratix/
+          git diff --cached --quiet && exit 0 || true
+
+          git commit -m"update kratix package"
+          git push origin main


### PR DESCRIPTION
Each workflow can be called (via a `workflow_call`) within another like any other action that can be `used` within a job. From the calling code, this is still visualised as a full workflow making all of the steps visible e.g. 

![image](https://github.com/user-attachments/assets/a6a9decd-9893-4967-816f-30b725566646)
