### PR TITLE
chore: verify before promoting a release

### DIFF
--- a/.github/workflows/promote-ske-pre-release.yaml
+++ b/.github/workflows/promote-ske-pre-release.yaml
@@ -38,6 +38,12 @@ jobs:
           GH_TOKEN: ${{ secrets.ENTERPRISE_KRATIX_GH_TOKEN }}
         run: |
           ./scripts/check-ske-release-does-not-exist
+      - name: Verify release images
+        run: |
+          ./scripts/verify-images ${{ env.LATEST_PRE_RELEASE_TAG }}
+      - name: Verify SBOM artifacts
+        run: |
+          ./scripts/verify-sboms ${{ env.LATEST_PRE_RELEASE_TAG }}
       - name: Re-tag SKE artifacts to full release
         env:
           GH_TOKEN: ${{ secrets.ENTERPRISE_KRATIX_GH_TOKEN }}


### PR DESCRIPTION
When promoting a ske release, add in pipeline stages to fail if the images/sboms aren't valid for the pre-release.