### PR TITLE
ci: pin to node 22 for headlamp image update

### DIFF
--- a/.github/workflows/bump-chainguard-images.yaml
+++ b/.github/workflows/bump-chainguard-images.yaml
@@ -52,7 +52,7 @@ jobs:
           latest_static="$(docker pull cgr.dev/chainguard/static:latest 2>/dev/null | grep -o 'sha256:[a-fA-F0-9]\+' | cut -d':' -f2)"
           latest_gitbase="$(docker pull cgr.dev/chainguard/git:latest 2>/dev/null | grep -o 'sha256:[a-fA-F0-9]\+' | cut -d':' -f2)"
           latest_golang="$(docker pull cgr.dev/chainguard/go:latest 2>/dev/null | grep -o 'sha256:[a-fA-F0-9]\+' | cut -d':' -f2)"
-          latest_node="$(docker pull cgr.dev/chainguard/node:latest 2>/dev/null | grep -o 'sha256:[a-fA-F0-9]\+' | cut -d':' -f2)"
+          latest_node="$(docker pull cgr.dev/chainguard/node:22 2>/dev/null | grep -o 'sha256:[a-fA-F0-9]\+' | cut -d':' -f2)"
 
           echo "latest_wolfi=$latest_wolfi" >> "$GITHUB_ENV"
           echo "latest_static=$latest_static" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Context

headlamp needs node 22: https://github.com/kubernetes-sigs/headlamp/blob/main/Dockerfile#L30

or else the image built will fail like: https://github.com/syntasso/enterprise-kratix/actions/runs/25735088861/job/75570566324