### PR TITLE
chore: set node.js version for github runners

### DIFF
--- a/.github/workflows/test-ske-backstage.yaml
+++ b/.github/workflows/test-ske-backstage.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           repository: syntasso/ci
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Common Environment
         uses: ./.github/actions/setup-common
         with:

--- a/.github/workflows/test-ske.yaml
+++ b/.github/workflows/test-ske.yaml
@@ -122,6 +122,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: syntasso/ci
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Setup Common Environment
         uses: ./.github/actions/setup-common
         with:


### PR DESCRIPTION
The runner is using node.js 20 and we recently updated backstage backend plugin to node.js 22. Therefore the tests in this CI are now failing 
https://github.com/syntasso/ci/actions/runs/26113064832/job/76918983560