### PR TITLE
chore: enable Dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 0
     groups:
       github-actions:
         patterns: ["*"]


### PR DESCRIPTION
Removes `open-pull-requests-limit: 0` from the github-actions Dependabot config.

Node.js 20 actions are being forced to Node.js 24 from June 2nd 2026. Actions in the ci repo need updating to Node.js 24-compatible versions. Enabling Dependabot so it raises the bump PRs.