### PR TITLE
fix: add fetch-depth: 0 to fix empty RC changelog

### DIFF
--- a/.github/workflows/create-ske-pre-release.yaml
+++ b/.github/workflows/create-ske-pre-release.yaml
@@ -20,6 +20,7 @@ jobs:
           ssh-key: ${{ secrets.ENTERPRISE_KRATIX_DEPLOY_KEY_READ_PUSH }}
           ref: ${{ github.event.inputs.ske_sha }}
           submodules: recursive
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Problem

RC release notes are empty. `generate-changelog` runs `git log v0.50.0..v0.51.0-rc2` but gets nothing back — the default shallow clone (`fetch-depth: 1`) doesn't have the commit history between tags.

`git fetch --tags` only helps when intermediate component tags (cortex, GUI) happen to land in the range and force git to fetch more history. Without them, it returns at most 1 commit.

## Fix

Add `fetch-depth: 0` to the enterprise-kratix checkout. Repo has ~2500 commits — adds ~2-5s to a 10min job.

## Evidence

Broken run (no intermediate tags in range): https://github.com/syntasso/ci/actions/runs/28526651126
Working run (cortex + GUI tags in range, accidentally unshallowed): https://github.com/syntasso/ci/actions/runs/26632925883