### PR TITLE
feat: add --build-context support to docker-build.sh

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -11,6 +11,7 @@ push="false"
 load="false"
 extra_tags=()
 build_args=()
+build_contexts=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -32,6 +33,8 @@ while [[ $# -gt 0 ]]; do
       extra_tags+=("$2"); shift 2 ;;
     --build-arg)
       build_args+=("--build-arg" "$2"); shift 2 ;;
+    --build-context)
+      build_contexts+=("--build-context" "$2"); shift 2 ;;
     *)
       echo "Unknown argument: $1" >&2
       exit 1 ;;
@@ -62,6 +65,9 @@ if ((${#extra_tags[@]} > 0)); then
 fi
 if ((${#build_args[@]} > 0)); then
   args+=("${build_args[@]}")
+fi
+if ((${#build_contexts[@]} > 0)); then
+  args+=("${build_contexts[@]}")
 fi
 
 if [[ "$push" == "true" ]]; then


### PR DESCRIPTION
\`ske-platform-manager\` uses a secondary build context (\`--build-context kratix=../read-only-kratix\`) in its Dockerfile. Without this flag, the shared script couldn't be used for that component and the build logic had to be duplicated inline in the Makefile.

Usage:
\`\`\`bash
../ci/scripts/docker-build.sh \
  --tag \${IMG} \
  --dockerfile ./Dockerfile \
  --context . \
  --build-context kratix=../read-only-kratix \
  --platforms linux/arm64,linux/amd64 \
  --builder ske-platform-manager-builder \
  --push true
\`\`\`