### PR TITLE
chore: pin all GitHub Actions to SHAs

### DIFF
--- a/.github/actions/setup-backstage/action.yaml
+++ b/.github/actions/setup-backstage/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout out backstage
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: syntasso/backstage
         ssh-key: ${{ inputs.backstage_deploy_key }}

--- a/.github/actions/setup-common/action.yaml
+++ b/.github/actions/setup-common/action.yaml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Checkout parameterized repository
       if: "${{ inputs.repository != '' }}"
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -58,7 +58,7 @@ runs:
 
     - name: Checkout submodule repository
       if: "${{ inputs.submodule_repository != '' && inputs.submodule_ref != '' }}"
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: ${{ inputs.submodule_repository }}
         ref: ${{ inputs.submodule_ref }}
@@ -66,13 +66,13 @@ runs:
 
     - name: Start tmate ssh debugging session
       if: "${{ inputs.ssh_session == 'true' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
       with:
         limit-access-to-actor: true
         detached: true
 
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: 1.26
         check-latest: true
@@ -87,7 +87,7 @@ runs:
         echo "CONTROLLER_TOOLS_VERSION=$(grep -E '^CONTROLLER_TOOLS_VERSION[[:space:]]*\?=' Makefile | tail -n1 | awk '{print $3}')" >> "$GITHUB_ENV"
 
     - name: Cache build tools
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ${{ inputs.tools_base_path }}/bin/kustomize*
@@ -102,12 +102,12 @@ runs:
         make kustomize
 
     - name: Install Kind
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         install_only: true
         version: v0.29.0
 
     - name: Setup Flux CLI
-      uses: fluxcd/flux2/action@main
+      uses: fluxcd/flux2/action@d708f5e2b791d4b3fcbe497e02806cb0fdae84b3 # main (no stable release)
       with:
         version: '2.4.0'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,4 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    groups:
-      github-actions:
-        patterns: ["*"]
+    # No grouping — individual PRs per action allow auto-merge to handle each update independently.

--- a/.github/workflows/bump-chainguard-images.yaml
+++ b/.github/workflows/bump-chainguard-images.yaml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Checkout enterprise-kratix repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/enterprise-kratix
           path: enterprise-kratix
           ssh-key: ${{ secrets.ENTERPRISE_KRATIX_DEPLOY_KEY_READ_PUSH }}
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: Fetch terraform outputs and place into env variables
         working-directory: enterprise-kratix/terraform
         run: |
@@ -32,7 +32,7 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ env.CI_USER_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.CI_USER_SECRET_ACCESS_KEY }}
@@ -94,7 +94,7 @@ jobs:
           git pull origin main --rebase
           git push origin main
       - name: Checkout ske-image repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ske-images
           ssh-key: ${{ secrets.SKE_IMAGES_DEPLOY_KEY_READ_PUSH }}
@@ -128,7 +128,7 @@ jobs:
           git commit -m "fix(deps): bump chainguard base image"
           git push origin main
       - name: Checkout port-controller repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ske-port-controller
           ssh-key: ${{ secrets.PORT_CONTROLLER_READ_WRITE_KEY }}

--- a/.github/workflows/create-ske-pre-release.yaml
+++ b/.github/workflows/create-ske-pre-release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out enterprise kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/enterprise-kratix
           ssh-key: ${{ secrets.ENTERPRISE_KRATIX_DEPLOY_KEY_READ_PUSH }}
@@ -22,24 +22,24 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.26
           check-latest: true
       - name: Set up Docker (pinned)
-        uses: docker/setup-docker-action@v5
+        uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
         with:
           version: 29.1.5
       - name: Snyk golang scan on kratix
         if: ${{ !inputs.skip-security-scan }}
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@12140f4059e244892ae643824a95459a102120dd # master (no stable release)
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           DOCKER_API_VERSION: "1.48"
         with:
           args: --severity-threshold=high
       - name: Login to ghcr
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: syntassodev
@@ -63,7 +63,7 @@ jobs:
           fi
           echo "NEW_TAG=$new_tag" >> "$GITHUB_ENV"
       - name: Snyk image scan on kratix
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@12140f4059e244892ae643824a95459a102120dd # master (no stable release)
         if: ${{ !inputs.skip-security-scan }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
           image: ghcr.io/syntasso/ske-platform:$NEW_TAG
           args: --severity-threshold=high --username=syntassodev --password=${{ secrets.GHCR_TOKEN }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: eu-west-2
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -98,7 +98,7 @@ jobs:
     needs: [create-pre-release]
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.ENTERPRISE_KRATIX_TEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ENTERPRISE_KRATIX_TEST_AWS_SECRET_ACCESS_KEY }}
@@ -106,9 +106,9 @@ jobs:
           role-to-assume: ${{ secrets.EKS_KUBECTL_ADMIN_ROLE_ARN }}
           role-session-name: test
           role-skip-session-tagging: true
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: Check out enterprise kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/enterprise-kratix
           ssh-key: ${{ secrets.ENTERPRISE_KRATIX_DEPLOY_KEY_READ_PUSH }}
@@ -120,7 +120,7 @@ jobs:
         env:
           TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.4
       - name: Upgrade LRE
@@ -148,7 +148,7 @@ jobs:
     needs: [create-pre-release]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Setup Common Environment

--- a/.github/workflows/kratix.yaml
+++ b/.github/workflows/kratix.yaml
@@ -23,13 +23,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
           repositories: kratix
       - name: Set pending status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -52,7 +52,7 @@ jobs:
               core.setFailed(`Failed to set pending status: ${error.message}`);
             }
       - name: Generate Summary
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const sha = ${{ toJson(github.event.inputs.sha) }}
@@ -113,7 +113,7 @@ jobs:
     if: "${{ github.event.inputs.sha != '' }}"
     steps:
       - name: Check out enterprise kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/enterprise-kratix
           submodules: recursive
@@ -147,14 +147,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
           repositories: kratix
 
       - name: Update Kratix commit status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/promote-ske-pre-release.yaml
+++ b/.github/workflows/promote-ske-pre-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out enterprise kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/enterprise-kratix
           ssh-key: ${{ secrets.ENTERPRISE_KRATIX_DEPLOY_KEY_READ_PUSH }}
@@ -29,7 +29,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ENTERPRISE_KRATIX_GH_TOKEN }}
       - name: Set up Docker (pinned)
-        uses: docker/setup-docker-action@v5
+        uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
         with:
           version: 29.1.5
       - name: Login to ghcr
@@ -92,7 +92,7 @@ jobs:
         run: |
           ./scripts/retag-ske-artifacts-to-full-release
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: eu-west-2
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release-kratix.yaml
+++ b/.github/workflows/release-kratix.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Check out kratix
         id: checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.ACTION_PUSH }}
@@ -68,16 +68,16 @@ jobs:
     needs: [tag-new-version]
     steps:
       - name: Check out kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/kratix
           ref: ${{ github.event.inputs.sha }}
       - name: Set up Docker (pinned)
-        uses: docker/setup-docker-action@v5
+        uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
         with:
           version: 29.1.5
       - name: Docker login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -90,16 +90,16 @@ jobs:
     needs: [tag-new-version]
     steps:
       - name: Check out kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/kratix
           ref: ${{ github.event.inputs.sha }}
       - name: Set up Docker (pinned)
-        uses: docker/setup-docker-action@v5
+        uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
         with:
           version: 29.1.5
       - name: Docker login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -114,13 +114,13 @@ jobs:
       - build-and-push-quick-start-installer
     steps:
       - name: Check out kratix
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         id: checkout
         with:
           repository: syntasso/kratix
           ref: ${{ github.event.inputs.sha }}
       - name: Checkout out kratix helm charts
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/helm-charts
           path: charts

--- a/.github/workflows/test-kratix.yaml
+++ b/.github/workflows/test-kratix.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Setup Common Environment
@@ -41,7 +41,7 @@ jobs:
           path: kratix
           ssh_session: ${{ github.event.inputs.ssh_session }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11
           working-directory: kratix
@@ -56,7 +56,7 @@ jobs:
     needs: [unit-tests-and-lint]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Start tmate ssh debugging session
         if: "${{ inputs.ssh_session == 'true' }}"
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
         with:
           limit-access-to-actor: true
           detached: true
@@ -83,7 +83,7 @@ jobs:
           echo "EXPORT_IMAGE_TAR=${EXPORT_IMAGE_TAR}" >> "${GITHUB_ENV}"
 
       - name: Upload Kratix image artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kratix-image-${{ github.run_id }}
           path: ${{ env.EXPORT_IMAGE_TAR }}
@@ -94,7 +94,7 @@ jobs:
     needs: [unit-tests-and-lint]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -113,7 +113,7 @@ jobs:
           echo "QUICK_START_INSTALLER_TAR=${QUICK_START_INSTALLER_TAR}" >> "${GITHUB_ENV}"
 
       - name: Upload quick-start installer image artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quick-start-installer-image-${{ github.run_id }}
           path: ${{ env.QUICK_START_INSTALLER_TAR }}
@@ -124,7 +124,7 @@ jobs:
     needs: [build-kratix-image, build-quick-start-installer-image]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -137,7 +137,7 @@ jobs:
           ssh_session: ${{ github.event.inputs.ssh_session }}
 
       - name: Download quick-start installer image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick-start-installer-image-${{ github.run_id }}
           path: ${{ runner.temp }}/quick-start-installer-image
@@ -148,7 +148,7 @@ jobs:
           docker load -i "${image_tar}"
 
       - name: Download Kratix image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kratix-image-${{ github.run_id }}
           path: ${{ runner.temp }}/kratix-image
@@ -187,7 +187,7 @@ jobs:
           echo "WORKER_STATESTORE_TYPE=$WORKER_STATESTORE_TYPE" >> "${GITHUB_ENV}"
 
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -200,7 +200,7 @@ jobs:
           ssh_session: ${{ github.event.inputs.ssh_session }}
 
       - name: Download quick-start installer image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quick-start-installer-image-${{ github.run_id }}
           path: ${{ runner.temp }}/quick-start-installer-image
@@ -211,7 +211,7 @@ jobs:
           docker load -i "${image_tar}"
 
       - name: Download Kratix image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kratix-image-${{ github.run_id }}
           path: ${{ runner.temp }}/kratix-image
@@ -244,7 +244,7 @@ jobs:
 
       - name: Gather controller logs and statuses
         if: ${{ always() && steps.system_tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.flags.name }}-system-test-debug-report
           path: output/debug-test
@@ -255,7 +255,7 @@ jobs:
     needs: [build-kratix-image]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -268,7 +268,7 @@ jobs:
           ssh_session: ${{ github.event.inputs.ssh_session }}
 
       - name: Download Kratix image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kratix-image-${{ github.run_id }}
           path: ${{ runner.temp }}/kratix-image
@@ -300,7 +300,7 @@ jobs:
           fi
       - name: Gather controller logs and statuses
         if: ${{ always() && steps.core_tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: core-test-debug-report
           path: output/debug-test
@@ -311,7 +311,7 @@ jobs:
     needs: [build-kratix-image]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -324,7 +324,7 @@ jobs:
           ssh_session: ${{ github.event.inputs.ssh_session }}
 
       - name: Download Kratix image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kratix-image-${{ github.run_id }}
           path: ${{ runner.temp }}/kratix-image
@@ -335,13 +335,13 @@ jobs:
           docker load -i "${image_tar}"
 
       - name: Checkout out kratix helm charts
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/helm-charts
           path: kratix/charts
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - name: e2e-demo-test-helm-git
         run: |
           cd kratix
@@ -354,7 +354,7 @@ jobs:
     needs: [build-kratix-image]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
@@ -367,7 +367,7 @@ jobs:
           ssh_session: ${{ github.event.inputs.ssh_session }}
 
       - name: Download Kratix image artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kratix-image-${{ github.run_id }}
           path: ${{ runner.temp }}/kratix-image
@@ -378,13 +378,13 @@ jobs:
           docker load -i "${image_tar}"
 
       - name: Checkout out kratix helm charts
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/helm-charts
           path: kratix/charts
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - name: e2e-demo-test-helm-bucket
         run: |
           cd kratix
@@ -397,7 +397,7 @@ jobs:
     needs: [unit-tests-and-lint]
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 

--- a/.github/workflows/test-ske-backstage.yaml
+++ b/.github/workflows/test-ske-backstage.yaml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
 

--- a/.github/workflows/test-ske.yaml
+++ b/.github/workflows/test-ske.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Setup Common Environment
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Setup Common Environment
@@ -77,7 +77,7 @@ jobs:
           tools_base_path: enterprise-kratix/read-only-kratix
           ssh_session: ${{ github.event.inputs.ssh_session }}
       - name: Install vCluster CLI
-        uses: loft-sh/setup-vcluster@main
+        uses: loft-sh/setup-vcluster@68e17a8c3618e3c47d635842b803d4f560f694e8 # main (no stable release)
       - name: Upgrade tests
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Setup Common Environment
@@ -119,11 +119,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
       - name: Setup Common Environment
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ci repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: syntasso/ci
       - name: Setup Common Environment

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.repo_token }}
         with:


### PR DESCRIPTION
Pins all external action refs to full 40-char SHAs with inline version comments. Removes Dependabot action grouping so each action gets its own update PR. 18 unique actions pinned across 9 workflow files. Part of syntasso/enterprise-kratix#969.