### PR TITLE
chore: remove the upgrade-lre job from the SKE pre-release

### DIFF
--- a/.github/workflows/create-ske-pre-release.yaml
+++ b/.github/workflows/create-ske-pre-release.yaml
@@ -93,56 +93,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ENTERPRISE_KRATIX_GH_TOKEN }}
 
-  upgrade-lre:
-    runs-on: ubuntu-latest
-    needs: [create-pre-release]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.ENTERPRISE_KRATIX_TEST_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENTERPRISE_KRATIX_TEST_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-          role-to-assume: ${{ secrets.EKS_KUBECTL_ADMIN_ROLE_ARN }}
-          role-session-name: test
-          role-skip-session-tagging: true
-      - uses: hashicorp/setup-terraform@v4
-      - name: Check out enterprise kratix
-        uses: actions/checkout@v7
-        with:
-          repository: syntasso/enterprise-kratix
-          ssh-key: ${{ secrets.ENTERPRISE_KRATIX_DEPLOY_KEY_READ_PUSH }}
-          ref: ${{ github.event.inputs.ske_sha }}
-          submodules: recursive
-      - name: Authenticate against LRE
-        run: |
-          ./scripts/authenticate-against-lre
-        env:
-          TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN_app_terraform_io }}
-      - name: Install Helm
-        uses: azure/setup-helm@v5
-        with:
-          version: v3.16.4
-      - name: Upgrade LRE
-        run: |
-          ./scripts/upgrade-lre $latest_rc
-        env:
-          GH_TOKEN: ${{ secrets.ENTERPRISE_KRATIX_GH_TOKEN }}
-          SKE_LICENSE_TOKEN: ${{ secrets.SKE_LICENSE_TOKEN }}
-      - name: Kratix core tests post upgrade
-        run: |
-          cd read-only-kratix
-          git status
-          make gitea-cli
-          # kratix tests are designed for 1 worker 1 platform
-          kubectl --context ${PLATFORM} label destinations.platform.kratix.io testing-worker-git environment-
-          set +e
-          LRE="true" WORKER_CONTEXT=${WORKER_BUCKET} WORKER_NAME=${WORKER_BUCKET} PLATFORM_CONTEXT=${PLATFORM} PLATFORM_NAME=${PLATFORM} DESTINATION_NAME=${WORKER_BUCKET} go run github.com/onsi/ginkgo/v2/ginkgo -v ./test/core/
-          status=$?
-          kubectl --context ${PLATFORM} label destinations.platform.kratix.io testing-worker-git environment=dev
-          set -e
-          exit $status
-
   ske-downgrade-test:
     runs-on: ubuntu-latest
     needs: [create-pre-release]


### PR DESCRIPTION
Removes the `upgrade-lre` job from `create-ske-pre-release.yaml`. Pairs with [syntasso/enterprise-kratix#1333](https://github.com/syntasso/enterprise-kratix/pull/1333), which removes the LRE leftovers from that repo now that the LRE lives in [syntasso/lre](https://github.com/syntasso/lre).
